### PR TITLE
Deployment: Smithery config

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,5 +1,7 @@
 # ClickUp MCP Server
 
+[![smithery badge](https://smithery.ai/badge/@mikah13/mcp-clickup)](https://smithery.ai/server/@mikah13/mcp-clickup)
+
 MCP Server for the ClickUp API, enabling Claude to interact with ClickUp workspaces.
 
 ## Tools

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,21 @@
+# Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
+
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required:
+      - apiToken
+      - workspaceId
+    properties:
+      apiToken:
+        type: string
+        description: The API token for ClickUp authentication.
+      workspaceId:
+        type: string
+        description: The ClickUp workspace ID.
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    config => ({command: 'node', args: ['dist/index.js'], env: {CLICKUP_API_TOKEN: config.apiToken, CLICKUP_WORKSPACE_ID: config.workspaceId}})


### PR DESCRIPTION
This pull request introduces the following updates:

- **Smithery Configuration**: Adds a Smithery YAML file, which specifies how to start the MCP and the configuration options it supports. It allows you to [deploy](https://smithery.ai/docs/deployments) your MCP to [Smithery](https://smithery.ai?utm_campaign=pr), serving it over WebSockets so end-users do not need to install additional dependencies. To deploy, merge this PR, then visit your [server page](https://smithery.ai/server/@mikah13/mcp-clickup?utm_campaign=pr&modal=claim) and click "Deploy" under the deployments page.
- **README**: Updates the README to include a popularity badge.

Please review these updates to verify their accuracy for your server and feel free to customize it to your needs. Let me know if you have any questions. 🙂